### PR TITLE
Use PascalCase in namespace (FastLogin)

### DIFF
--- a/wp-fast-login.php
+++ b/wp-fast-login.php
@@ -14,7 +14,7 @@
  * Domain Path:       /languages
  */
 
-namespace salcode\fastLogin;
+namespace salcode\FastLogin;
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {


### PR DESCRIPTION
WordPress core does not use namespaces currently, so there is no WP
standard to follow there.

Arguably, since namespaces correspond to autoloading paths it would make
sense to use kabob case (e.g. "fast-login") to match the WordPress core
filename rules. However, in my opinion it is popular (and accepted
even?) to use PascalCase in classnames (and namespaces).

Examples:

- WebDevStudios excludes the "WordPress.Files.FileName.NotHyphenatedLowercase"
  check in their PHPCS configuration
  (https://github.com/WebDevStudios/php-coding-standards/blob/f2763a3984e8647f63a101c4ce79bb61ad25db3c/WebDevStudios/ruleset.xml#L13)
- Here is an example of WebDevStudios using PascalCase
  (https://github.com/WebDevStudios/oops-wp/blob/458bc9ddf32d8bbb86f19ba0c676f07a61b58798/src/Structure/Plugin/Plugin.php#L10-L21)
- See also the Human Made coding standards
  (https://engineering.hmn.md/standards/style/php/#namespace-and-class-naming)

Regarding the lowercasing of "salcode" as the namespace, the PSR-4
standard says "Alphabetic characters in the fully qualified class name
MAY be any combination of lower case and upper case."

Since it is not explicitly required to use capitals, I prefer to use all
lower-case for "salcode".

See https://www.php-fig.org/psr/psr-4/

See #14