### PR TITLE
Wrap code in function_exists() checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Add `CHANGELOG.md` ([#27](https://github.com/salcode/wp-fast-login/issues/27))
 - Enqueue `wp-util` for WP 6.5 compatibility ([#26](https://github.com/salcode/wp-fast-login/issues/26))
+- Add check for duplicate plugin activation (e.g. plugin and mu-plugin) ([#13](https://github.com/salcode/wp-fast-login/issues/13))
 
 ## 0.1.0
 - Initial release

--- a/wp-fast-login.php
+++ b/wp-fast-login.php
@@ -27,100 +27,100 @@ if (
 	! function_exists( __NAMESPACE__ . '\add_rest_api_route' ) &&
 	! function_exists( __NAMESPACE__ . '\print_user_option_tags' )
 ) {
-add_action( 'login_form', __NAMESPACE__ . '\print_user_dropdown' );
-add_action( 'login_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
-add_action( 'rest_api_init', __NAMESPACE__ . '\add_rest_api_route');
+	add_action( 'login_form', __NAMESPACE__ . '\print_user_dropdown' );
+	add_action( 'login_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
+	add_action( 'rest_api_init', __NAMESPACE__ . '\add_rest_api_route');
 
-function add_rest_api_route() {
-	register_rest_route( 'wp-fast-login/v1', '/login/(?P<id>[\d]+)', [
-		'callback' => function( $request ) {
-			$user_id = $request['id'];
-			wp_set_auth_cookie( $user_id, TRUE );
-			return rest_ensure_response([ 'userId' => $user_id ]);
-		},
-		'permission_callback' => '__return_true',
-		'methods'  => \WP_REST_Server::CREATABLE, // POST
-	]);
-}
+	function add_rest_api_route() {
+		register_rest_route( 'wp-fast-login/v1', '/login/(?P<id>[\d]+)', [
+			'callback' => function( $request ) {
+				$user_id = $request['id'];
+				wp_set_auth_cookie( $user_id, TRUE );
+				return rest_ensure_response([ 'userId' => $user_id ]);
+			},
+			'permission_callback' => '__return_true',
+			'methods'  => \WP_REST_Server::CREATABLE, // POST
+		]);
+	}
 
-function enqueue_scripts() {
-	wp_localize_script(
-		'wp-util',
-		'wpFastLogin',
-		[
-			'destination' =>
-				filter_input( INPUT_GET, 'redirect_to', FILTER_VALIDATE_URL ) ?:
-				get_admin_url(),
-			'restUrl' => get_rest_url(),
-		]
-	);
-}
-
-function print_user_dropdown() {
-	$args = [
-		'number' => 100,
-		'role' => 'Administrator',
-	];
-	$user_query = new \WP_User_Query( $args );
-?>
-<div>
-	<label for="fast-login">Fast login</label><br>
-	<select
-		id="fast-login"
-	>
-		<option default value="">Select a User</option>
-		<?php
-			print_user_option_tags( [
-				'number' => 100,
-				'role' => 'Administrator'
-			]);
-
-			print_user_option_tags( [
-				'number' => 100,
-				'role__not_in' => [ 'Administrator' ]
-			]);
-		?>
-	</select>
-	<br><br>
-</div>
-<script>
-document.getElementById('fast-login').addEventListener(
-  'input', async function(evt) {
-    if (! this.value) {
-      // No user selected. Return early with no changes.
-       return;
-    }
-    try {
-      const userId = await fetch(
-        `${wpFastLogin.restUrl}wp-fast-login/v1/login/${this.value}`,
-        { method: 'POST' }
-      ).then((response) => response.json())
-      .then((json) => json.userId);
-
-      if (! userId) {
-        throw new Error( 'Attempt to login failed' );
-      }
-      window.location.href = wpFastLogin.destination;
-    } catch (err) {
-      alert(err);
-    }
-  }
-);
-</script>
-<?php
-}
-
-function print_user_option_tags( $args ) {
-	$user_query = new \WP_User_Query( $args );
-	foreach ( $user_query->get_results() as $user ) {
-		printf(
-			'<option value="%d">%s (%s)</option>',
-			$user->ID,
-			esc_html( $user->user_login ),
-			esc_html( implode( ',', $user->roles ) )
+	function enqueue_scripts() {
+		wp_localize_script(
+			'wp-util',
+			'wpFastLogin',
+			[
+				'destination' =>
+					filter_input( INPUT_GET, 'redirect_to', FILTER_VALIDATE_URL ) ?:
+					get_admin_url(),
+				'restUrl' => get_rest_url(),
+			]
 		);
 	}
-}
+
+	function print_user_dropdown() {
+		$args = [
+			'number' => 100,
+			'role' => 'Administrator',
+		];
+		$user_query = new \WP_User_Query( $args );
+	?>
+	<div>
+		<label for="fast-login">Fast login</label><br>
+		<select
+			id="fast-login"
+		>
+			<option default value="">Select a User</option>
+			<?php
+				print_user_option_tags( [
+					'number' => 100,
+					'role' => 'Administrator'
+				]);
+
+				print_user_option_tags( [
+					'number' => 100,
+					'role__not_in' => [ 'Administrator' ]
+				]);
+			?>
+		</select>
+		<br><br>
+	</div>
+	<script>
+	document.getElementById('fast-login').addEventListener(
+	  'input', async function(evt) {
+		if (! this.value) {
+		  // No user selected. Return early with no changes.
+		   return;
+		}
+		try {
+		  const userId = await fetch(
+			`${wpFastLogin.restUrl}wp-fast-login/v1/login/${this.value}`,
+			{ method: 'POST' }
+		  ).then((response) => response.json())
+		  .then((json) => json.userId);
+
+		  if (! userId) {
+			throw new Error( 'Attempt to login failed' );
+		  }
+		  window.location.href = wpFastLogin.destination;
+		} catch (err) {
+		  alert(err);
+		}
+	  }
+	);
+	</script>
+	<?php
+	}
+
+	function print_user_option_tags( $args ) {
+		$user_query = new \WP_User_Query( $args );
+		foreach ( $user_query->get_results() as $user ) {
+			printf(
+				'<option value="%d">%s (%s)</option>',
+				$user->ID,
+				esc_html( $user->user_login ),
+				esc_html( implode( ',', $user->roles ) )
+			);
+		}
+	}
 } else {
 	error_log( 'The wp-fast-login plugin functions already exist, it is likely you are running this plugin twice (as a plugin and an mu-plugin).' );
 }

--- a/wp-fast-login.php
+++ b/wp-fast-login.php
@@ -21,6 +21,12 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+if (
+	! function_exists( __NAMESPACE__ . '\print_user_dropdown' ) &&
+	! function_exists( __NAMESPACE__ . '\enqueue_scripts' ) &&
+	! function_exists( __NAMESPACE__ . '\add_rest_api_route' ) &&
+	! function_exists( __NAMESPACE__ . '\print_user_option_tags' )
+) {
 add_action( 'login_form', __NAMESPACE__ . '\print_user_dropdown' );
 add_action( 'login_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\add_rest_api_route');
@@ -114,4 +120,7 @@ function print_user_option_tags( $args ) {
 			esc_html( implode( ',', $user->roles ) )
 		);
 	}
+}
+} else {
+	error_log( 'The wp-fast-login plugin functions already exist, it is likely you are running this plugin twice (as a plugin and an mu-plugin).' );
 }


### PR DESCRIPTION
Wrap code in `function_exists()` checks to prevent redefining functions, particularly in the case where the plugin is being running both as a  plugin and as a mu-plugin

Resolves #13

**Note**: This PR is easier to review if you `Hide whitespace changes`

![image](https://user-images.githubusercontent.com/5194588/120631912-66fbfb00-c436-11eb-854f-3bb38e70fbf4.png)
