### PR TITLE
Replace localize with inline_script for WP 6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Add `CHANGELOG.md` ([#27](https://github.com/salcode/wp-fast-login/issues/27))
+- Change from `wp_localize_script()` to `wp_add_inline_script()` for compatibility with WordPress 6.5 ([#26](https://github.com/salcode/wp-fast-login/issues/26))
 
 ## 0.1.0
 - Initial release

--- a/wp-fast-login.php
+++ b/wp-fast-login.php
@@ -38,15 +38,14 @@ function add_rest_api_route() {
 }
 
 function enqueue_scripts() {
-	wp_localize_script(
+	wp_add_inline_script(
 		'wp-util',
-		'wpFastLogin',
-		[
+		'var wpFastLogin = ' . json_encode( [
 			'destination' =>
 				filter_input( INPUT_GET, 'redirect_to', FILTER_VALIDATE_URL ) ?:
 				get_admin_url(),
 			'restUrl' => get_rest_url(),
-		]
+		] )
 	);
 }
 


### PR DESCRIPTION
Replace wp_localize_script() with wp_add_inline_script() for compatibility with WordPress 6.5

Resolves #26