### PR TITLE
Enqueue wp-util for WP 6.5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Add `CHANGELOG.md` ([#27](https://github.com/salcode/wp-fast-login/issues/27))
+- Enqueue `wp-util` for WP 6.5 compatibility ([#26](https://github.com/salcode/wp-fast-login/issues/26))
 
 ## 0.1.0
 - Initial release

--- a/wp-fast-login.php
+++ b/wp-fast-login.php
@@ -38,6 +38,7 @@ function add_rest_api_route() {
 }
 
 function enqueue_scripts() {
+	wp_enqueue_script( 'wp-util' );
 	wp_localize_script(
 		'wp-util',
 		'wpFastLogin',


### PR DESCRIPTION
This is a work-around for WordPress 6.5 until
https://core.trac.wordpress.org/ticket/60862
is resolved.

Resolves #26